### PR TITLE
Ensuring proper mint time sequencing for public sale and pre-sale

### DIFF
--- a/sources/candymachine.move
+++ b/sources/candymachine.move
@@ -73,7 +73,7 @@ module candymachine::candymachine{
         move_to<ResourceInfo>(&resource_signer_from_cap, ResourceInfo{resource_cap: resource_cap, source: signer::address_of(account)});
         assert!(vector::length(&collection_mutate_setting) == 3 && vector::length(&token_mutate_setting) == 5, error::invalid_argument(INVALID_MUTABLE_CONFIG));
         assert!(royalty_points_denominator > 0, error::invalid_argument(EINVALID_ROYALTY_NUMERATOR_DENOMINATOR));
-        assert!(public_sale_mint_time >=  now && presale_mint_time >= now, error::invalid_argument(EINVALID_MINT_TIME));
+        assert!(presale_mint_time >=  now && public_sale_mint_time >= presale_mint_time, error::invalid_argument(EINVALID_MINT_TIME));
         assert!(royalty_points_numerator <= royalty_points_denominator, error::invalid_argument(EINVALID_ROYALTY_NUMERATOR_DENOMINATOR));
         let whitelist = vector::empty<address>();
         let candies_data = create_bit_mask(total_supply);


### PR DESCRIPTION
Fixed issue where public sale mint time was not properly set to be greater than or equal to the pre-sale mint time. Updated the logic to ensure that the public sale mint time is always set to be equal to or greater than the pre-sale mint time.